### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/css010/7e831291-c01f-44ff-b8a1-297f2e38507d/c123de82-3074-468f-a8a4-2a0ed7070d0a/_apis/work/boardbadge/f9355d64-1ec9-4b7d-aad1-6255a88e5c5d)](https://dev.azure.com/css010/7e831291-c01f-44ff-b8a1-297f2e38507d/_boards/board/t/c123de82-3074-468f-a8a4-2a0ed7070d0a/Microsoft.RequirementCategory)
 # react-chess
 # typescript-react-chess
 # typescript-react-chess


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/css010/7e831291-c01f-44ff-b8a1-297f2e38507d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.